### PR TITLE
rename lessThen to lessThan

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $rate = $user->getRate();
 verify('first user rate is 7', $rate)->equals(7);
 
 verify($rate)->greaterThan(5);
-verify($rate)->lessThen(10);
+verify($rate)->lessThan(10);
 verify($rate)->lessOrEquals(7);
 verify($rate)->lessOrEquals(8);
 verify($rate)->greaterOrEquals(7);

--- a/src/Codeception/Verify.php
+++ b/src/Codeception/Verify.php
@@ -46,7 +46,7 @@ class Verify {
         a::assertGreaterThan($expected, $this->actual, $this->description);
     }
 
-    public function lessThen($expected)
+    public function lessThan($expected)
     {
         a::assertLessThan($expected, $this->actual, $this->description);
     }

--- a/tests/VerifyTest.php
+++ b/tests/VerifyTest.php
@@ -20,7 +20,7 @@ class VerifyTest extends PHPUnit_Framework_TestCase {
     public function testGreaterLowerThen()
     {
         verify(7)->greaterThan(5);
-        verify(7)->lessThen(10);
+        verify(7)->lessThan(10);
         verify(7)->lessOrEquals(7);
         verify(7)->lessOrEquals(8);
         verify(7)->greaterOrEquals(7);


### PR DESCRIPTION
I think `lessThen` must be a typo.  I've corrected it to `lessThan` in this pull request.