### PR TITLE
Allow comparing floats with delta.

### DIFF
--- a/src/Codeception/Verify.php
+++ b/src/Codeception/Verify.php
@@ -30,19 +30,19 @@ class Verify {
         $this->isFileExpectation = $isFileExpectation;
     }
 
-    public function equals($expected)
+    public function equals($expected, $delta = 0)
     {
         if ( ! $this->isFileExpectation ) {
-            a::assertEquals($expected, $this->actual, $this->description);
+            a::assertEquals($expected, $this->actual, $this->description, $delta);
         } else {
             a::assertFileEquals($expected, $this->actual, $this->description);
         }
     }
 
-    public function notEquals($expected)
+    public function notEquals($expected, $delta = 0)
     {
         if ( ! $this->isFileExpectation ) {
-            a::assertNotEquals($expected, $this->actual, $this->description);
+            a::assertNotEquals($expected, $this->actual, $this->description, $delta);
         } else {
             a::assertFileNotEquals($expected, $this->actual, $this->description);
         }

--- a/tests/VerifyTest.php
+++ b/tests/VerifyTest.php
@@ -12,13 +12,22 @@ class VerifyTest extends PHPUnit_Framework_TestCase {
         $this->xml = new DomDocument;
         $this->xml->loadXML('<foo><bar>Baz</bar><bar>Baz</bar></foo>');
     }
+    
     public function testEquals()
     {
         verify(5)->equals(5);
         verify("hello")->equals("hello");
         verify("user have 5 posts", 5)->equals(5);
-        verify(3)->notEquals(5);
+        verify(3.251)->equals(3.25, 0.01);
+        verify("respects delta", 3.251)->equals(3.25, 0.01);
         verify_file(__FILE__)->equals(__FILE__);
+    }
+
+    public function testNotEquals()
+    {
+        verify(3)->notEquals(5);
+        verify(3.252)->notEquals(3.25, 0.001);
+        verify("respects delta", 3.252, 0.001);
         verify_file(__FILE__)->notEquals(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'composer.json');
     }
 


### PR DESCRIPTION
Right now, if you want to compare floats, you still have to use PHPUnit's `assertEquals`. With this back-compatible change, you could have more consistent tests.

The following statements are equivalent:
```php
verify("Quantity is correct up to the thousandth.", $quantity)->equals(100.25, 0.001)
$this->assertEquals(100.25, $quantity, "Quantity is correct up to the thousandth", 0.001)
```