### PR TITLE
Fix ClassNotFound for PHPUnit > v6

### DIFF
--- a/src/Codeception/function.php
+++ b/src/Codeception/function.php
@@ -1,4 +1,8 @@
 <?php
+if (!class_exists('PHPUnit_Framework_Assert') && class_exists('PHPUnit\Framework\Assert')) {
+    class_alias('PHPUnit\Framework\Assert', 'PHPUnit_Framework_Assert');
+}
+
 if (!function_exists('verify')) {
 
     /**


### PR DESCRIPTION
This will fix the "Class 'PHPUnit_Framework_Assert' not found" error which occurs on using PHPUnit 6.0 and above. Issue Ticket: https://github.com/Codeception/Verify/issues/30