### PR TITLE
Refactor count/notCount parameter name

### DIFF
--- a/src/Codeception/Verify.php
+++ b/src/Codeception/Verify.php
@@ -184,14 +184,14 @@ class Verify {
         a::assertContainsOnlyInstancesOf($class, $this->actual, $this->description);
     }
 
-    public function count($array)
+    public function count($expectedCount)
     {
-        a::assertCount($array, $this->actual, $this->description);
+        a::assertCount($expectedCount, $this->actual, $this->description);
     }
 
-    public function notCount($array)
+    public function notCount($expectedCount)
     {
-        a::assertNotCount($array, $this->actual, $this->description);
+        a::assertNotCount($expectedCount, $this->actual, $this->description);
     }
 
     public function equalXMLStructure($xml, $checkAttributes = FALSE)


### PR DESCRIPTION
The current parameter name for these two methods is `$array` with no type suggested in PHPDoc. This could mislead the API consumer that this method accepts a parameter of type array.

Checking into the source code, we can see that this method in fact calls PHPUnit's `assertCount`, which takes the expected count as it's first parameter. I think that `$expectedCount` would be a more appropriate name for this parameter, and it's the same name as used in PHPUnit's `assertCount` method, which makes sense.