### PR TITLE
Add objectHasProperty assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Verify is open-sourced software licensed under the [MIT][9] License.
 [4]: https://chaijs.com/
 [5]: https://jasmine.github.io/
 [6]: https://rspec.info/
-[7]: /docs/supported_verifiers.md
-[8]: /docs/supported_expectations.md
-[9]: /LICENSE
-[10]: /UPGRADE.md
+[7]: ./docs/supported_verifiers.md
+[8]: ./docs/supported_expectations.md
+[9]: ./LICENSE
+[10]: ./UPGRADE.md

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-dom": "*",
-        "phpunit/phpunit": "^9.5 | ^10.0"
+        "phpunit/phpunit": "^9.6.11 || ^10.0"
     },
     "autoload": {
         "files": [

--- a/docs/supported_expectations.md
+++ b/docs/supported_expectations.md
@@ -23,6 +23,8 @@ toHaveSameSizeAs
 ```
 notToHaveAttribute
 toHaveAttribute
+notToHaveProperty
+toHaveProperty
 ```
 
 ### Callable

--- a/docs/supported_expectations.md
+++ b/docs/supported_expectations.md
@@ -21,8 +21,6 @@ toHaveSameSizeAs
 
 ### BaseObject
 ```
-notToHaveAttribute
-toHaveAttribute
 notToHaveProperty
 toHaveProperty
 ```

--- a/docs/supported_verifiers.md
+++ b/docs/supported_verifiers.md
@@ -23,6 +23,8 @@ sameSize
 ```
 hasAttribute
 notHasAttribute
+hasProperty
+notHasProperty
 ```
 
 ### Callable

--- a/docs/supported_verifiers.md
+++ b/docs/supported_verifiers.md
@@ -21,8 +21,6 @@ sameSize
 
 ### BaseObject
 ```
-hasAttribute
-notHasAttribute
 hasProperty
 notHasProperty
 ```

--- a/src/Codeception/Verify/Expectations/ExpectAny.php
+++ b/src/Codeception/Verify/Expectations/ExpectAny.php
@@ -98,6 +98,18 @@ class ExpectAny extends ExpectMixed
         return $this;
     }
 
+    public function baseObjectToHaveProperty(string $propertyName, string $message = ''): self
+    {
+        Expect::BaseObject($this->actual)->toHaveProperty($propertyName, $message);
+        return $this;
+    }
+
+    public function baseObjectNotToHaveProperty(string $propertyName, string $message = ''): self
+    {
+        Expect::BaseObject($this->actual)->notToHaveProperty($propertyName, $message);
+        return $this;
+    }
+
     public function callableToThrow($throws = null, string $message = ''): self
     {
         Expect::Callable($this->actual)->toThrow($throws, $message);

--- a/src/Codeception/Verify/Expectations/ExpectBaseObject.php
+++ b/src/Codeception/Verify/Expectations/ExpectBaseObject.php
@@ -46,4 +46,30 @@ class ExpectBaseObject extends Expect
         Assert::assertObjectHasAttribute($attributeName, $this->actual, $message);
         return $this;
     }
+
+    /**
+     * Expect that an object does not have a specified property.
+     *
+     * @param string $propertyName
+     * @param string $message
+     * @return self
+     */
+    public function notToHaveProperty(string $propertyName, string $message = ''): self
+    {
+        Assert::assertObjectNotHasProperty($propertyName, $this->actual, $message);
+        return $this;
+    }
+
+    /**
+     * Expect that an object has a specified property.
+     *
+     * @param string $propertyName
+     * @param string $message
+     * @return self
+     */
+    public function toHaveProperty(string $propertyName, string $message = ''): self
+    {
+        Assert::assertObjectHasProperty($propertyName, $this->actual, $message);
+        return $this;
+    }
 }

--- a/src/Codeception/Verify/Expectations/ExpectBaseObject.php
+++ b/src/Codeception/Verify/Expectations/ExpectBaseObject.php
@@ -24,18 +24,22 @@ class ExpectBaseObject extends Expect
     /**
      * Expect that an object does not have a specified attribute.
      *
+     * @deprecated Deprecated in favour of notToHaveProperty
+     *
      * @param string $attributeName
      * @param string $message
      * @return self
      */
     public function notToHaveAttribute(string $attributeName, string $message = ''): self
     {
-        Assert::assertObjectNotHasAttribute($attributeName, $this->actual, $message);
+        Assert::assertObjectNotHasProperty($attributeName, $this->actual, $message);
         return $this;
     }
 
     /**
      * Expect that an object has a specified attribute.
+     *
+     * @deprecated Deprecated in favour of toHaveProperty
      *
      * @param string $attributeName
      * @param string $message
@@ -43,7 +47,7 @@ class ExpectBaseObject extends Expect
      */
     public function toHaveAttribute(string $attributeName, string $message = ''): self
     {
-        Assert::assertObjectHasAttribute($attributeName, $this->actual, $message);
+        Assert::assertObjectHasProperty($attributeName, $this->actual, $message);
         return $this;
     }
 

--- a/src/Codeception/Verify/Verifiers/VerifyAny.php
+++ b/src/Codeception/Verify/Verifiers/VerifyAny.php
@@ -98,6 +98,18 @@ class VerifyAny extends VerifyMixed
         return $this;
     }
 
+    public function baseObjectHasProperty(string $propertyName, string $message = ''): self
+    {
+        Verify::BaseObject($this->actual)->hasProperty($propertyName, $message);
+        return $this;
+    }
+
+    public function baseObjectNotHasProperty(string $propertyName, string $message = ''): self
+    {
+        Verify::BaseObject($this->actual)->notHasProperty($propertyName, $message);
+        return $this;
+    }
+
     public function callableThrows($throws = null, string $message = ''): self
     {
         Verify::Callable($this->actual)->throws($throws, $message);

--- a/src/Codeception/Verify/Verifiers/VerifyBaseObject.php
+++ b/src/Codeception/Verify/Verifiers/VerifyBaseObject.php
@@ -46,4 +46,30 @@ class VerifyBaseObject extends Verify
         Assert::assertObjectNotHasAttribute($attributeName, $this->actual, $message);
         return $this;
     }
+
+    /**
+     * Verifies that an object has a specified property.
+     *
+     * @param string $propertyName
+     * @param string $message
+     * @return self
+     */
+    public function hasProperty(string $propertyName, string $message = ''): self
+    {
+        Assert::assertObjectHasProperty($propertyName, $this->actual, $message);
+        return $this;
+    }
+
+    /**
+     * Verifies that an object does not have a specified property.
+     *
+     * @param string $propertyName
+     * @param string $message
+     * @return self
+     */
+    public function notHasProperty(string $propertyName, string $message = ''): self
+    {
+        Assert::assertObjectNotHasProperty($propertyName, $this->actual, $message);
+        return $this;
+    }
 }

--- a/src/Codeception/Verify/Verifiers/VerifyBaseObject.php
+++ b/src/Codeception/Verify/Verifiers/VerifyBaseObject.php
@@ -24,18 +24,22 @@ class VerifyBaseObject extends Verify
     /**
      * Verifies that an object has a specified attribute.
      *
+     * @deprecated Deprecated in favour of hasProperty
+     *
      * @param string $attributeName
      * @param string $message
      * @return self
      */
     public function hasAttribute(string $attributeName, string $message = ''): self
     {
-        Assert::assertObjectHasAttribute($attributeName, $this->actual, $message);
+        Assert::assertObjectHasProperty($attributeName, $this->actual, $message);
         return $this;
     }
 
     /**
      * Verifies that an object does not have a specified attribute.
+     *
+     * @deprecated Deprecated in favour of notHasProperty
      *
      * @param string $attributeName
      * @param string $message
@@ -43,7 +47,7 @@ class VerifyBaseObject extends Verify
      */
     public function notHasAttribute(string $attributeName, string $message = ''): self
     {
-        Assert::assertObjectNotHasAttribute($attributeName, $this->actual, $message);
+        Assert::assertObjectNotHasProperty($attributeName, $this->actual, $message);
         return $this;
     }
 

--- a/tests/ExpectTest.php
+++ b/tests/ExpectTest.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+include_once __DIR__.'/../src/Codeception/bootstrap.php';
+
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+
+final class ExpectTest extends TestCase
+{
+
+    public function testObjectToHaveProperty(): void
+    {
+        $object = new \Stdclass();
+        $object->bar = 'baz';
+
+        expect($object)->baseObjectToHaveProperty('bar');
+
+        verify(function () use ($object): void {
+            expect($object)->baseObjectToHaveProperty('foo', 'foobar');
+        })->callableThrows(new ExpectationFailedException("foobar\nFailed asserting that object of class \"stdClass\" has property \"foo\"."));
+    }
+
+    public function testObjectNotToHaveProperty(): void
+    {
+        $object = new \Stdclass();
+        $object->bar = 'baz';
+
+        expect($object)->baseObjectNotToHaveProperty('foo');
+
+        verify(function () use ($object): void {
+            expect($object)->baseObjectNotToHaveProperty('bar', 'foobar');
+        })->callableThrows(new ExpectationFailedException("foobar\nFailed asserting that object of class \"stdClass\" does not have property \"bar\"."));
+    }
+}

--- a/tests/VerifyTest.php
+++ b/tests/VerifyTest.php
@@ -324,6 +324,30 @@ final class VerifyTest extends TestCase
             verify($func)->callableDoesNotThrow(Exception::class, 'foo');
         })->callableThrows(new ExpectationFailedException("exception 'Exception' with message 'foo' was not expected to be thrown"));
     }
+
+    public function testObjectHasProperty(): void
+    {
+        $object = new \Stdclass();
+        $object->bar = 'baz';
+
+        verify($object)->baseObjectHasProperty('bar');
+
+        verify(function () use ($object): void {
+            verify($object)->baseObjectHasProperty('foo', 'foobar');
+        })->callableThrows(new ExpectationFailedException("foobar\nFailed asserting that object of class \"stdClass\" has property \"foo\"."));
+    }
+
+    public function testObjectNotHasProperty(): void
+    {
+        $object = new \Stdclass();
+        $object->bar = 'baz';
+
+        verify($object)->baseObjectNotHasProperty('foo');
+
+        verify(function () use ($object): void {
+            verify($object)->baseObjectNotHasProperty('bar', 'foobar');
+        })->callableThrows(new ExpectationFailedException("foobar\nFailed asserting that object of class \"stdClass\" does not have property \"bar\"."));
+    }
 }
 
 


### PR DESCRIPTION
With phpunit 10.x, `assertObjectHasAttribute` is deprecated in favor of `assertObjectHasProperty`

This adds the new alternatives.

See https://github.com/sebastianbergmann/phpunit/issues/4601