### PR TITLE
Extend docblock about same and equals regarding their type safety

### DIFF
--- a/src/Codeception/Verify/Verifiers/VerifyMixed.php
+++ b/src/Codeception/Verify/Verifiers/VerifyMixed.php
@@ -32,11 +32,12 @@ class VerifyMixed extends Verify
     }
 
     /**
-     * Verifies that two variables are equal.
+     * Verifies that two variables are equal without comparing the type.
      *
      * @param $expected
      * @param string $message
      * @return self
+     * @see same for comparing values and their types (type-safe comparison)
      */
     public function equals($expected, string $message = ''): self
     {
@@ -630,6 +631,7 @@ class VerifyMixed extends Verify
      * @param $expected
      * @param string $message
      * @return self
+     * @see equals for comparing variables in a non-type-safe manner
      */
     public function same($expected, string $message = ''): self
     {


### PR DESCRIPTION
I've stumbled into a mean error in my tests by using `verify()->equals()` all the time assuming it would perform a type safe comparison. At a certain point, I found out that I must use `verify()->same()` for a type safe comparison. Since I wasn't aware of `equals` being type-unsafe and `same` existing, I've added a bit about them to their respective documentation blocks in the hope it will help others as well.